### PR TITLE
Dev hashinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Crypt::Password::StretchedHash - simple library for password hashing and stretch
 
 # SYNOPSIS
 
+This module provides Generation / Verification method for hashed password string.
+There are two methods to handle parameters simply.
+
     use Test::More;
     use Crypt::Password::StretchedHash;
     use Digest::SHA;
@@ -27,6 +30,36 @@ Crypt::Password::StretchedHash - simple library for password hashing and stretch
         stretch_count   => 5000,
         format          => q{base64},
     );
+
+    unless ( $result ) {
+        # password error
+    }
+
+if you use class of the hash information(Crypt::Passwoed::SaltedHash::HashInfo),
+there are two methods to generate/verify string for DB Store. 
+
+    use Your::Password::HashInfo;
+    use Crypt::Password::StretchedHash;
+    
+
+    my $hash_info = Your::Password::HashInfo->new;
+    # crypt
+    my $password = ...;
+    my $pwhash_with_hashinfo = crypt_with_hashinfo(
+        password    => $password,
+        hash_info   => $hash_info,
+    );
+    
+
+    # verify
+    my $password = ...;
+    my $pwhash_with_hashinfo = ...;
+    my $result = verify_with_hashinfo(
+        password        => $password,
+        password_hash   => $pwhash_with_hashinfo,
+        hash_info   => $hash_info,
+    );
+    
 
     unless ( $result ) {
         # password error
@@ -79,6 +112,15 @@ This uses the following hash algorithm.
 ## verify( %params ) : Int
 
 Verifies stretched password hash.
+This compares the value of $params{password\_hash} with the generated using crypt method.
+
+## crypt\_with\_hashinfo( %params ) : String
+
+Generates stretched password hash with hash information.
+
+## verify\_with\_hashinfo( %params ) : Int
+
+Verifies stretched password hash with hash information.
 This compares the value of $params{password\_hash} with the generated using crypt method.
 
 # LICENSE

--- a/lib/Crypt/Password/StretchedHash.pm
+++ b/lib/Crypt/Password/StretchedHash.pm
@@ -14,7 +14,6 @@ use MIME::Base64 qw(
 );
 use Params::Validate qw(
     SCALAR
-    OBJECT
 );
 
 our @EXPORT = qw(crypt verify crypt_with_hashinfo verify_with_hashinfo);
@@ -24,7 +23,7 @@ sub crypt {
 
     my %params = Params::Validate::validate(@_, {
         password        => { type => SCALAR },
-        hash            => { type => OBJECT },
+        hash            => 1,
         salt            => { type => SCALAR },
         stretch_count   => { type => SCALAR, regex => qr/\A[0-9]+\z/,},
         format          => { type => SCALAR, optional => 1 },
@@ -63,7 +62,7 @@ sub verify {
     my %params = Params::Validate::validate(@_, {
         password        => { type => SCALAR },
         password_hash   => { type => SCALAR },
-        hash            => { type => OBJECT },
+        hash            => 1,
         salt            => { type => SCALAR },
         stretch_count   => { type => SCALAR, regex => qr/\A[0-9]+\z/,},
         format          => { type => SCALAR, optional => 1 },
@@ -80,7 +79,7 @@ sub crypt_with_hashinfo {
 
     my %params = Params::Validate::validate(@_, {
         password    => { type => SCALAR },
-        hash_info   => { type => OBJECT },
+        hash_info   => 1,
     });
 
     # validate hashinfo object
@@ -120,7 +119,7 @@ sub verify_with_hashinfo {
     my %params = Params::Validate::validate(@_, {
         password        => { type => SCALAR },
         password_hash   => { type => SCALAR },
-        hash_info       => { type => OBJECT },
+        hash_info       => 1,
     });
 
     # validate hashinfo object

--- a/lib/Crypt/Password/StretchedHash/HashInfo.pm
+++ b/lib/Crypt/Password/StretchedHash/HashInfo.pm
@@ -1,0 +1,183 @@
+package Crypt::Password::StretchedHash::HashInfo;
+
+use strict;
+use warnings;
+
+sub new {
+    my $class = shift;
+    my $self = bless {}, $class;
+    return $self;
+}
+
+sub delimiter {
+    my $self = shift;
+    die "This is abstract method. You have to return delimiter string.";
+}
+
+sub identifier {
+    my $self = shift;
+    die "This is abstract method. You have to return identifier of your HashInfo.";
+}
+
+sub hash {
+    my $self = shift;
+    die "This is abstract method. You have to return Digest::SHA or Digest::SHA3 object.";
+}
+
+sub salt {
+    my $self = shift;
+    die "This is abstract method. This is called at the time of first crypt. You have to return randomized salt string for each users.";
+}
+
+sub stretch_count {
+    my $self = shift;
+    die "This is abstract method. You have to return stretch count.";
+}
+
+sub format {
+    my $self = shift;
+    die "This is abstract method. You have to return format for hashed password representation.";
+}
+
+1;
+
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Crypt::Password::StretchedHash - Base class that specifies accessor for password information.
+
+=head1 DESCRIPTION
+
+Crypt::Password::StretchedHash::HashInfo is base class that specifies accessor for password information.
+You have to inherit this, and implements subroutines according to the interface contract.
+
+=head1 SYNOPSIS
+
+You implement your HashInfo class as follows.
+
+    package Your::Password::HashInfo;
+    use parent 'Crypt::Password::StretchedHash::HashInfo';
+    use Digest::SHA;
+    use Crypt::OpenSSL::Random;
+    use constant STRETCH_COUNT => 5000;
+    
+    sub delimiter {
+        my $self = shift;
+        return q{$};
+    }
+    
+    sub identifier {
+        my $self = shift;
+        return q{1};
+    }
+    
+    sub hash {
+        my $self = shift;
+        return Digest::SHA->new("sha256");
+    }
+    
+    sub salt {
+        my $self = shift;
+        return Crypt::OpenSSL::Random::random_pseudo_bytes(32);
+    }
+    
+    sub stretch_count {
+        my $self = shift;
+        return STRETCH_COUNT;
+    }
+   
+    sub format {
+        my $self = shift;
+        return q{base64};
+    }
+
+By passing your hashinfo to Crypt::Password::StretchedHash->crypt_with_hashinfo method,
+you obtain the hashed password with identifier and salt.
+
+    use Crypt::Password::StretchedHash qw(
+        crypt_with_hashinfo
+    );
+    use Your::Password::HashInfo;
+    
+    my $password = ...;
+    my $hash_info = Your::Password::HashInfo->new;
+    my $pwhash_with_hashinfo = crypt_with_hashinfo(
+        password    => $password,
+        hash_info   => $hash_info,
+    );
+
+It is similar at the time of the verification,
+you pass your hashinfo to Crypt::Password::StretchedHash->verify_with_hashinfo method.
+
+    use Crypt::Password::StretchedHash qw(
+        verify_with_hashinfo
+    );
+    use Your::Password::HashInfo;
+    
+    my $password = ...;
+    my $pwhash_with_hashinfo = ...;
+    my $hash_info = Your::Password::HashInfo->new;
+    my $is_valid = verify_with_hashinfo(
+        password        => $password,
+        password_hash   => $pwhash_with_hashinfo,
+        hash_info   => $hash_info,
+    );
+
+=head1 METHODS
+
+=head2 new : Object
+
+constructor
+
+=head2 delimiter : String
+
+It returns delimiter string.
+If delimiter is "$", generated string is as follows.
+
+    $(identifier)$(salt)$(hashed password)
+
+=head2 identifier : String
+
+It returns identifier of hashinfo.
+If delimiter is "$" and identifier is "1", generated string is as follows.
+
+    $1$(salt)$(hashed password)
+
+=head2 hash : Object
+
+It returns hash object.
+In the current version, only Digest::SHA and Digest::SHA3 are allowed.
+
+=head2 stretch_count : Int
+
+It returns stretching count, and if has to be an integer bigger than 0.
+
+=head2 format : String
+
+It returns hash object.
+In the current version, only "hex" and "base64" are allowed.
+
+=head2 salt : String
+
+It returns salt string.
+It may be binary strings.
+If delimiter is "$" ,identifier is "1", format is "base64", salt is "test12345" generated string is as follows.
+
+    $1$dGVzdDEyMzQ1$(hashed password)
+
+=head1 LICENSE
+
+Copyright (C) Ryo Ito.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=head1 AUTHOR
+
+Ryo Ito E<lt>ritou.06@gmail.comE<gt>
+
+=cut
+

--- a/t/00_compile.t
+++ b/t/00_compile.t
@@ -3,6 +3,7 @@ use Test::More;
 
 use_ok $_ for qw(
     Crypt::Password::StretchedHash
+    Crypt::Password::StretchedHash::HashInfo
 );
 
 done_testing;

--- a/t/03_hashinfo.t
+++ b/t/03_hashinfo.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Crypt::Password::StretchedHash::HashInfo;
+
+TEST_NEW: {
+
+    my $hash_info = Crypt::Password::StretchedHash::HashInfo->new;
+    ok ( $hash_info, q{constructor is returned} );
+
+};
+
+TEST_ABSTRACT: {
+
+    my $hash_info = Crypt::Password::StretchedHash::HashInfo->new;
+    my ($delimiter, $identifier, $hash, $salt, $stretch_count, $format);
+    eval{
+        $delimiter = $hash_info->delimiter; 
+    };
+    ok ( $@, q{hash_info->delimiter is abstract method} );
+
+    eval{
+        $identifier = $hash_info->identifier; 
+    };
+    ok ( $@, q{hash_info->identifier is abstract method} );
+
+    eval{
+        $hash = $hash_info->hash; 
+    };
+    ok ( $@, q{hash_info->hash is abstract method} );
+
+    eval{
+        $salt = $hash_info->salt; 
+    };
+    ok ( $@, q{hash_info->salt is abstract method} );
+
+    eval{
+        $stretch_count = $hash_info->stretch_count; 
+    };
+    ok ( $@, q{hash_info->stretch_count is abstract method} );
+
+    eval{
+        $format = $hash_info->format; 
+    };
+    ok ( $@, q{hash_info->format is abstract method} );
+
+};
+
+done_testing;

--- a/t/04_hashinfo.t
+++ b/t/04_hashinfo.t
@@ -1,0 +1,190 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Crypt::Password::StretchedHash;
+use Digest::SHA;
+use lib 't/lib';
+use TestHashInfo;
+
+TEST_TESTHASHINFO: {
+    my $hash_info = TestHashInfo->new;
+    ok( $hash_info, q{TestHashInfo} );
+};
+
+TEST_CRYPT_WITH_HASHINFO: {
+    my $hash_info = TestHashInfo->new;
+    $hash_info->set_delimiter(q{$});
+    $hash_info->set_identifier(q{1});
+    $hash_info->set_hash(Digest::SHA->new("sha256"));
+    $hash_info->set_salt(q{test_salt_1234567890});
+    $hash_info->set_stretch_count(5000);
+    $hash_info->set_format(q{base64});
+
+    my $pwhash = Crypt::Password::StretchedHash->crypt_with_hashinfo(
+        password    => q{password},
+        hash_info   => $hash_info,
+    );
+    ok( $pwhash, q{pwhash is returned});
+    is( $pwhash, q{$1$dGVzdF9zYWx0XzEyMzQ1Njc4OTA=$6t8PoejG3He/QujMmN1MpBi5iwNY9t0mdl+OHOwceo0=}, q{pwhash is matched} );
+
+    # delimiter
+    $hash_info->set_delimiter(q{%});
+    $pwhash = Crypt::Password::StretchedHash->crypt_with_hashinfo(
+        password    => q{password},
+        hash_info   => $hash_info,
+    );
+    ok( $pwhash, q{pwhash is returned});
+    is( $pwhash, q{%1%dGVzdF9zYWx0XzEyMzQ1Njc4OTA=%6t8PoejG3He/QujMmN1MpBi5iwNY9t0mdl+OHOwceo0=}, q{delimiter} );
+    $hash_info->set_delimiter(q{$});
+
+    # identifier
+    $hash_info->set_identifier(q{2});
+    $pwhash = Crypt::Password::StretchedHash->crypt_with_hashinfo(
+        password    => q{password},
+        hash_info   => $hash_info,
+    );
+    ok( $pwhash, q{pwhash is returned});
+    is( $pwhash, q{$2$dGVzdF9zYWx0XzEyMzQ1Njc4OTA=$6t8PoejG3He/QujMmN1MpBi5iwNY9t0mdl+OHOwceo0=}, q{identifier} );
+    $hash_info->set_identifier(q{1});
+
+    # hash
+    $hash_info->set_hash(Digest::SHA->new("sha512"));
+    $pwhash = Crypt::Password::StretchedHash->crypt_with_hashinfo(
+        password    => q{password},
+        hash_info   => $hash_info,
+    );
+    ok( $pwhash, q{pwhash is returned});
+    is( $pwhash, q{$1$dGVzdF9zYWx0XzEyMzQ1Njc4OTA=$4V/aqHXUQKExBIoUOkaAON/6735mL7zXdu6Zpby0237bXxnZfGjc5ocdkeLJjsqUMxMwa/5vyw+1lCcxaQJUBA==}, q{hash} );
+    $hash_info->set_hash(Digest::SHA->new("sha256"));
+
+    # salt
+    $hash_info->set_salt(q{test_salt2_1234567890});
+    $pwhash = Crypt::Password::StretchedHash->crypt_with_hashinfo(
+        password    => q{password},
+        hash_info   => $hash_info,
+    );
+    ok( $pwhash, q{pwhash is returned});
+    is( $pwhash, q{$1$dGVzdF9zYWx0Ml8xMjM0NTY3ODkw$Uah1f76DiyXz/l9vPcYrhPNhDh3EDfc+npYDMT4DKe0=}, q{salt} );
+    $hash_info->set_salt(q{test_salt_1234567890});
+
+    # stretch_count
+    $hash_info->set_stretch_count(q{1000});
+    $pwhash = Crypt::Password::StretchedHash->crypt_with_hashinfo(
+        password    => q{password},
+        hash_info   => $hash_info,
+    );
+    ok( $pwhash, q{pwhash is returned});
+    is( $pwhash, q{$1$dGVzdF9zYWx0XzEyMzQ1Njc4OTA=$fpq0X06qxQg/e4UR2DnaRyU7vPHgXO0V5A7Puy0q5jQ=}, q{stretch_count} );
+    $hash_info->set_stretch_count(q{5000});
+
+    # format : hex
+    $hash_info->set_format(q{hex});
+    $pwhash = Crypt::Password::StretchedHash->crypt_with_hashinfo(
+        password    => q{password},
+        hash_info   => $hash_info,
+    );
+    ok( $pwhash, q{pwhash is returned});
+    is( $pwhash, q{$1$746573745f73616c745f31323334353637383930$eadf0fa1e8c6dc77bf42e8cc98dd4ca418b98b0358f6dd26765f8e1cec1c7a8d}, q{format is hex} );
+    $hash_info->set_format(q{base64});
+};
+
+TEST_VERIFY_WITH_HASHINFO: {
+    my $hash_info = TestHashInfo->new;
+    $hash_info->set_delimiter(q{$});
+    $hash_info->set_identifier(q{1});
+    $hash_info->set_hash(Digest::SHA->new("sha256"));
+    $hash_info->set_salt(q{test_salt_1234567890});
+    $hash_info->set_stretch_count(5000);
+    $hash_info->set_format(q{base64});
+
+    my $result = Crypt::Password::StretchedHash->verify_with_hashinfo(
+        password        => q{password},
+        password_hash   => q{invalid_password_hash},
+        hash_info       => $hash_info,
+    );
+    ok( !$result, q{password is not matched});
+
+    $result = Crypt::Password::StretchedHash->verify_with_hashinfo(
+        password        => q{password},
+        password_hash   => q{$1$dGVzdF9zYWx0XzEyMzQ1Njc4OTA=$6t8PoejG3He/QujMmN1MpBi5iwNY9t0mdl+OHOwceo0=},
+        hash_info       => $hash_info,
+    );
+    ok( $result, q{password is matched});
+
+    $result = Crypt::Password::StretchedHash->verify_with_hashinfo(
+        password        => q{password},
+        password_hash   => q{$$dGVzdF9zYWx0XzEyMzQ1Njc4OTA=$6t8PoejG3He/QujMmN1MpBi5iwNY9t0mdl+OHOwceo0=},
+        hash_info       => $hash_info,
+    );
+    ok( !$result, q{no identifier});
+
+    $result = Crypt::Password::StretchedHash->verify_with_hashinfo(
+        password        => q{password},
+        password_hash   => q{$1$$6t8PoejG3He/QujMmN1MpBi5iwNY9t0mdl+OHOwceo0=},
+        hash_info       => $hash_info,
+    );
+    ok( !$result, q{no salt});
+
+    $result = Crypt::Password::StretchedHash->verify_with_hashinfo(
+        password        => q{password},
+        password_hash   => q{$1$dGVzdF9zYWx0XzEyMzQ1Njc4OTA=$},
+        hash_info       => $hash_info,
+    );
+    ok( !$result, q{no password hash});
+
+    $hash_info->set_delimiter(q{%});
+    $result = Crypt::Password::StretchedHash->verify_with_hashinfo(
+        password        => q{password},
+        password_hash   => q{$1$dGVzdF9zYWx0XzEyMzQ1Njc4OTA=$6t8PoejG3He/QujMmN1MpBi5iwNY9t0mdl+OHOwceo0=},
+        hash_info       => $hash_info,
+    );
+    ok( !$result, q{delimiter is different});
+    $hash_info->set_delimiter(q{$});
+    
+    $hash_info->set_identifier(q{2});
+    $result = Crypt::Password::StretchedHash->verify_with_hashinfo(
+        password        => q{password},
+        password_hash   => q{$1$dGVzdF9zYWx0XzEyMzQ1Njc4OTA=$6t8PoejG3He/QujMmN1MpBi5iwNY9t0mdl+OHOwceo0=},
+        hash_info       => $hash_info,
+    );
+    ok( !$result, q{identifier is different});
+    $hash_info->set_identifier(q{1});
+    
+    $hash_info->set_hash(Digest::SHA->new("sha512"));
+    $result = Crypt::Password::StretchedHash->verify_with_hashinfo(
+        password        => q{password},
+        password_hash   => q{$1$dGVzdF9zYWx0XzEyMzQ1Njc4OTA=$6t8PoejG3He/QujMmN1MpBi5iwNY9t0mdl+OHOwceo0=},
+        hash_info       => $hash_info,
+    );
+    ok( !$result, q{hash function is different});
+    $hash_info->set_hash(Digest::SHA->new("sha256"));
+
+    $result = Crypt::Password::StretchedHash->verify_with_hashinfo(
+        password        => q{password},
+        password_hash   => q{$1$dGVzdF9zYWx0Ml8xMjM0NTY3ODkw$6t8PoejG3He/QujMmN1MpBi5iwNY9t0mdl+OHOwceo0=},
+        hash_info       => $hash_info,
+    );
+    ok( !$result, q{salt is different});
+
+    $hash_info->set_stretch_count(4999);
+    $result = Crypt::Password::StretchedHash->verify_with_hashinfo(
+        password        => q{password},
+        password_hash   => q{$1$dGVzdF9zYWx0XzEyMzQ1Njc4OTA=$6t8PoejG3He/QujMmN1MpBi5iwNY9t0mdl+OHOwceo0=},
+        hash_info       => $hash_info,
+    );
+    ok( !$result, q{stretch_count is different});
+    $hash_info->set_stretch_count(5000);
+
+    $hash_info->set_format(q{hex});
+    $result = Crypt::Password::StretchedHash->verify_with_hashinfo(
+        password        => q{password},
+        password_hash   => q{$1$dGVzdF9zYWx0XzEyMzQ1Njc4OTA=$6t8PoejG3He/QujMmN1MpBi5iwNY9t0mdl+OHOwceo0=},
+        hash_info       => $hash_info,
+    );
+    ok( !$result, q{format is different});
+    $hash_info->set_format(q{base64});
+
+};
+
+done_testing;

--- a/t/lib/TestHashInfo.pm
+++ b/t/lib/TestHashInfo.pm
@@ -1,0 +1,74 @@
+package TestHashInfo;
+
+use parent 'Crypt::Password::StretchedHash::HashInfo';
+use Digest::SHA;
+   
+my $_delimiter = q{$};
+my $_identifier = q{1};
+my $_hash = Digest::SHA->new("sha256");
+my $_salt = q{test_salt_1234567890};
+my $_stretch_count = 5000;
+my $_format = q{base64};
+
+sub delimiter {
+    my $self = shift;
+    return $_delimiter;
+}
+
+sub identifier {
+    my $self = shift;
+    return $_identifier;
+}
+
+sub hash {
+    my $self = shift;
+    return $_hash;
+}
+
+sub salt {
+    my $self = shift;
+    return $_salt;
+}
+
+sub stretch_count {
+    my $self = shift;
+    return $_stretch_count;
+}
+
+sub format {
+    my $self = shift;
+    return $_format;
+}
+
+# setter
+sub set_delimiter {
+    my ($self, $delimiter) = @_;
+    $_delimiter = $delimiter;
+}
+
+sub set_identifier {
+    my ($self, $identifier) = @_;
+    $_identifier = $identifier;
+}
+
+sub set_hash {
+    my ($self, $hash) = @_;
+    $_hash = $hash;
+}
+
+sub set_salt {
+    my ($self, $salt) = @_;
+    $_salt = $salt;
+}
+
+sub set_stretch_count {
+    my ($self, $stretch_count) = @_;
+    $_stretch_count = $stretch_count;
+}
+
+sub set_format {
+    my ($self, $format) = @_;
+    $_format = $format;
+}
+
+1;


### PR DESCRIPTION
## Added HashInfo class and crypt/verify methods.

This commit related with issue #1.
https://github.com/ritou/p5-Crypt-Password-StretchedHash/issues/1
## Remove OBJECT validation by Params::Validate

This commit related with tester's report.
http://www.cpantesters.org/cpan/report/0f2924f6-d971-11e2-8ad3-1b2260117a5d
